### PR TITLE
fix: snmp driver compose for rootless implementation

### DIFF
--- a/snmp-driver-compose.yml
+++ b/snmp-driver-compose.yml
@@ -12,6 +12,9 @@ services:
     networks:
       - 01-cdm
     mem_limit: 300mb
+    cap_add:
+      - NET_RAW
+      - NET_ADMIN
     volumes:
       - ./cfg-data:/shared-cfg/
     command:


### PR DESCRIPTION
SNMP 1.4.x requires container capabilities which are hereby set